### PR TITLE
Refresh access_token

### DIFF
--- a/lib/omniauth/strategies/bolt.rb
+++ b/lib/omniauth/strategies/bolt.rb
@@ -60,11 +60,16 @@ module OmniAuth
         post_data = URI.encode_www_form(payload)
         res = http.request(req, post_data)
         response = JSON.parse(res.body)
+
         @expiration_time = Time.now.utc + response['expires_in']
         @refresh_token = response['refresh_token']
         @refresh_token_scope = response['refresh_token_scope']
         @access_token = response['access_token']
         @user_uid = response['id_token']
+
+        # don't need these values to refresh access_token so better remove them
+        session.delete('authorization_code')
+        session.delete('scope')
 
         super
       end

--- a/lib/omniauth/strategies/bolt.rb
+++ b/lib/omniauth/strategies/bolt.rb
@@ -60,6 +60,9 @@ module OmniAuth
         post_data = URI.encode_www_form(payload)
         res = http.request(req, post_data)
         response = JSON.parse(res.body)
+        @expiration_time = Time.now.utc + response['expires_in']
+        @refresh_token = response['refresh_token']
+        @refresh_token_scope = response['refresh_token_scope']
         @access_token = response['access_token']
         @user_uid = response['id_token']
 


### PR DESCRIPTION
Bolt has developed an option to refresh the access_token after
expiration. In order to do that we have to send an API call to the same
endpoint with a different payload. This commit implements that option.

Requirement for https://github.com/nebulab/solidus_bolt/issues/101

Manually tested: `refresh_token`, `refresh_token_scope`, and `expiration_time` do appear in the session