### PR TITLE
Update Strategy for changes in bolt oauth

### DIFF
--- a/lib/omniauth-bolt/version.rb
+++ b/lib/omniauth-bolt/version.rb
@@ -2,6 +2,6 @@
 
 module OmniAuth
   module Bolt
-    VERSION = '0.1.0'
+    VERSION = '0.2.0'
   end
 end

--- a/lib/omniauth/strategies/bolt.rb
+++ b/lib/omniauth/strategies/bolt.rb
@@ -30,20 +30,21 @@ module OmniAuth
         }
       end
 
-      def request_phase
-        session[:authorization_code] = request.params['authorization_code']
-        session[:scope] = request.params['scope']
+      def query_string
+        "?authorization_code=#{request.params['code']}&scope=#{request.params['scope']}&state=#{request.params['state']}"
+      end
 
+      def request_phase
         redirect callback_url
       end
 
       def callback_phase
         payload = {
           grant_type: 'authorization_code',
-          code: session['authorization_code'],
+          code: request.params['authorization_code'],
           client_id: options['publishable_key'],
           # scope: 'openid+bolt.account.manage',
-          scope: session['scope'],
+          scope: request.params['scope'],
           client_secret: options['api_key']
         }
 


### PR DESCRIPTION
This PR updates the strategy to make sure that it works with changes in the bolt oauth

The `request phase` now directly redirects to the `callback_url` with the `authorization_code`, `scope` and `state` as the params.
The `callback phase` then interacts with this data directly than using it from the session to complete the oauth process.