### PR TITLE
Modify Query String for Authorization Code

### DIFF
--- a/lib/omniauth/strategies/bolt.rb
+++ b/lib/omniauth/strategies/bolt.rb
@@ -31,7 +31,8 @@ module OmniAuth
       end
 
       def query_string
-        "?authorization_code=#{request.params['code']}&scope=#{request.params['scope']}&state=#{request.params['state']}"
+        authorization_code = request.params['code'] || request.params['authorization_code']
+        "?authorization_code=#{authorization_code}&scope=#{request.params['scope']}&state=#{request.params['state']}"
       end
 
       def request_phase


### PR DESCRIPTION
Modified the query string method to catch authorization code from either the "authorization_code" param or the "code" param.

This was done to mitigate unexpected behaviour for Bolt SSO on the bolt-demo site.