### PR TITLE
Pass scope

### DIFF
--- a/lib/omniauth-bolt/version.rb
+++ b/lib/omniauth-bolt/version.rb
@@ -2,6 +2,6 @@
 
 module OmniAuth
   module Bolt
-    VERSION = '0.3.0'
+    VERSION = '0.3.1'
   end
 end

--- a/lib/omniauth/strategies/bolt.rb
+++ b/lib/omniauth/strategies/bolt.rb
@@ -68,6 +68,7 @@ module OmniAuth
         @refresh_token_scope = response['refresh_token_scope']
         @access_token = response['access_token']
         @user_uid = response['id_token']
+        @scope = response['scope']
 
         # don't need these values to refresh access_token so better remove them
         session.delete('authorization_code')


### PR DESCRIPTION
The only distinction between a new access_token and a refreshed one is
in the scope. Since we now need to make the distinction in the
solidus_bolt extension, we need to pass the scope from here.
